### PR TITLE
<system_error> header is added for c++ 11 mutex

### DIFF
--- a/lib/mutex.cpp
+++ b/lib/mutex.cpp
@@ -30,6 +30,7 @@
 
 #if defined(HT_MUTEX_IMPL_CPP11)
 #  include <mutex>
+#  include <system_error>
 #  define HT_MUTEX_TYPE_ std::mutex
 #elif defined(HT_MUTEX_IMPL_POSIX)
 #  include <pthread.h>


### PR DESCRIPTION
<system_error> is required for std::system_error usage

*Issue #, if available:*
Build of HawkTracer for closed platform failed with a message about missing system_error class. 

*Description of changes:*
Adding required <system_error> header for C++11 mutex implementation fixes the issue. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
